### PR TITLE
add encoding

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ except Exception:
     print(traceback.print_exc())
     exit(-1)
 
-with open('README.md', 'r') as fh:
+with open('README.md', 'r',encoding='utf-8') as fh:
     LONG_DESCRIPTION = fh.read()
 
 # Guannan add windows platform support on 2014/11/4 20:04


### PR DESCRIPTION
environment: win10, Python 3.6.7 :: Anaconda, Inc.  
when I want to install cup by source,it shows  
 `Traceback (most recent call last):                                                                                        File "setup.py", line 28, in <module>                                                                                     LONG_DESCRIPTION = fh.read()                                                                                        UnicodeDecodeError: 'gbk' codec can't decode byte 0xa4 in position 159: illegal multibyte sequence   `  

