### PR TITLE
fix bug `cup.util.conf.Dict2Configure::write_conf`

### DIFF
--- a/cup/util/conf.py
+++ b/cup/util/conf.py
@@ -1101,7 +1101,7 @@ class Dict2Configure(object):
     def _appendline(self, key, value):
         self._str = '{0}{1}{2}{3}{4}{5}'.format(
             self._str, self._get_indents(), key, self._get_field_value_sep(),
-            self._encoding, self._get_linesep()
+            value, self._get_linesep()
         )
 
     def _addlevel(self, key):


### PR DESCRIPTION
BUG description: 
`cup.util.conf.Dict2Configure::write_conf` write all values as `utf8`:

```
key1:utf8
key2:utf8
```

how to reproduce:
```python
from cup.util.conf import Dict2Configure
Dict2Configure({'key1': 'val1', 'key2': 'val2'}).write_conf('test.conf')
```